### PR TITLE
[controller] Do not redeploy ceph-csi-config

### DIFF
--- a/images/controller/src/pkg/controller/ceph_cluster_connection_watcher_func.go
+++ b/images/controller/src/pkg/controller/ceph_cluster_connection_watcher_func.go
@@ -227,6 +227,10 @@ func reconcileConfigMapUpdateFunc(ctx context.Context, cl client.Client, log log
 	log.Trace(fmt.Sprintf("[reconcileConfigMapUpdateFunc] updated ConfigMap: %+v", updatedConfigMap))
 	log.Trace(fmt.Sprintf("[reconcileConfigMapUpdateFunc] old ConfigMap: %+v", oldConfigMap))
 
+	if updatedConfigMap.Data["config.json"] == "null" {
+		panic("NULLLLL")
+	}
+
 	err = cl.Update(ctx, updatedConfigMap)
 	if err != nil {
 		err = fmt.Errorf("[reconcileConfigMapUpdateFunc] unable to update the ConfigMap %s for CephClusterConnection %s: %w", updatedConfigMap.Name, cephClusterConnection.Name, err)
@@ -313,6 +317,7 @@ func updateConfigMap(oldConfigMap *corev1.ConfigMap, cephClusterConnection *v1al
 	newJSONData, _ := json.Marshal(clusterConfigs)
 
 	configMap := oldConfigMap.DeepCopy()
+
 	configMap.Data["config.json"] = string(newJSONData)
 
 	if configMap.Labels == nil {

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | indent 2 }}
 data:
   config.json: |-
-{{ toJson .Values.csiCeph.internal.csiConfig | indent 4 }}
+{{ .Values.csiCeph.internal.csiConfig | indent 4 }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -2,16 +2,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ceph-csi-config
-  namespace: d8-{{ .Chart.Name }}
-{{ include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | indent 2 }}
-data:
-  config.json: |-
-{{ .Values.csiCeph.internal.csiConfig | indent 4 }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
   name: ceph-config
   namespace: d8-{{ .Chart.Name }}
 {{ include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | indent 2 }}


### PR DESCRIPTION
## Description
ConfigMap `ceph-csi-config` should not be delivered with a template, this makes it being redeployed on each module update, that's why `config.json` is being periodically updated to `null`.

After removing it from the template, it will be deleted, and we need to make sure controller will remove it's finalizer and re-create it.

## Why do we need it, and what problem does it solve?
This fixes the issue of `ceph-csi-config/config.json` being periodically updated to `null`.

## What is the expected result?
Expected sequence of events after deploy:
1. ConfigMap `ceph-csi-config` will be deleted (`DeletedTimestamp` will be set)
2. Controller will be restarted, so it will receive CREATE events for every `CephClusterConnection`. The first such event will delete finalizer from the deleted CM and requeue the event.
3. The next CREATE event (or the same one, after being requeued) will create the config map and fill it with correct information.

If there're no `CephClusterConnection` objects currently, CM will be re-created when the first `CephClusterConnection` will be created.

## Checklist
- [X] Changes were tested in the Kubernetes cluster manually.
