### PR TITLE
[controller] Fix permissions in csi-controller-rbd for /tmp/csi-addons.sock creation

### DIFF
--- a/templates/rbd/controller.yaml
+++ b/templates/rbd/controller.yaml
@@ -237,7 +237,7 @@
 {{- $_ := set $csiControllerConfig "additionalControllerVolumes" (include "rbd_csi_controller_volumes" . | fromYamlArray) }}
 {{- $_ := set $csiControllerConfig "additionalControllerVolumeMounts" (include "rbd_csi_controller_volume_mounts" . | fromYamlArray) }}
 {{- $_ := set $csiControllerConfig "additionalContainers" (include "rbd_csi_additional_containers" (list $csiDriverName $csiControllerImage) | fromYamlArray) }}
-
+{{- $_ := set $csiControllerConfig "runAsRootUser" true }}
 {{- $_ := set $csiControllerConfig "livenessProbePort" 4247 }}
 
 {{- include "helm_lib_csi_controller_manifests" (list . $csiControllerConfig) }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR resolves an issue in `csi-controller-rbd` where the creation of the `/tmp/csi-addons.sock` socket failed due to insufficient permissions. Previously, when running with a non-root user, the process encountered a `bind: permission denied` error. To address this, `csi-controller-rbd` is now executed as `root`, ensuring proper permissions for socket creation.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Previously, `csi-controller-rbd` encountered permission issues when trying to create the `/tmp/csi-addons.sock` socket under a restricted user. This caused failures in controller operations that rely on this socket. Running the controller as `root` resolves this issue by granting the necessary privileges for creating and binding the socket, ensuring compatibility with CSI drivers that require elevated permissions.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
