### PR TITLE
[csi] Revert root privileges enable and fix absent mounts for rbd plugin

### DIFF
--- a/templates/rbd/controller.yaml
+++ b/templates/rbd/controller.yaml
@@ -237,7 +237,7 @@
 {{- $_ := set $csiControllerConfig "additionalControllerVolumes" (include "rbd_csi_controller_volumes" . | fromYamlArray) }}
 {{- $_ := set $csiControllerConfig "additionalControllerVolumeMounts" (include "rbd_csi_controller_volume_mounts" . | fromYamlArray) }}
 {{- $_ := set $csiControllerConfig "additionalContainers" (include "rbd_csi_additional_containers" (list $csiDriverName $csiControllerImage) | fromYamlArray) }}
-{{- $_ := set $csiControllerConfig "runAsRootUser" true }}
+{{- $_ := set $csiControllerConfig "runAsRootUser" false }}
 {{- $_ := set $csiControllerConfig "livenessProbePort" 4247 }}
 
 {{- include "helm_lib_csi_controller_manifests" (list . $csiControllerConfig) }}

--- a/templates/rbd/controller.yaml
+++ b/templates/rbd/controller.yaml
@@ -127,6 +127,8 @@
     #   mountPath: /etc/ceph/
     - name: keys-tmp-dir
       mountPath: /tmp/csi/keys
+    - name: tmp
+      mountPath: /tmp
 {{- end }}
 
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Because of problems in rbdplugin we enabled root privileges in csi controller for rbd. Mount fix makes it unnecessary.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Working rbd csi controller

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
