### PR TITLE
[internal] scale prometheus operator while migrating

### DIFF
--- a/hooks/go/020-webhook-certs/webhook-certs.go
+++ b/hooks/go/020-webhook-certs/webhook-certs.go
@@ -19,8 +19,8 @@ package hooks_common
 import (
 	"fmt"
 
-	tlscertificate "github.com/deckhouse/module-sdk/common-hooks/tls-certificate"
 	consts "github.com/deckhouse/csi-ceph/hooks/go/consts"
+	tlscertificate "github.com/deckhouse/module-sdk/common-hooks/tls-certificate"
 )
 
 var _ = tlscertificate.RegisterInternalTLSHookEM(tlscertificate.GenSelfSignedTLSHookConf{

--- a/hooks/go/030-remove-sc-and-secrets-on-module-delete/remove-sc-and-secrets-on-module-delete.go
+++ b/hooks/go/030-remove-sc-and-secrets-on-module-delete/remove-sc-and-secrets-on-module-delete.go
@@ -37,7 +37,6 @@ import (
 	"github.com/deckhouse/sds-common-lib/kubeclient"
 )
 
-
 func removeFinalizers(ctx context.Context, cl client.Client, obj client.Object, logger pkg.Logger) error {
 	logger.Info(fmt.Sprintf("[remove-sc-and-secrets-on-module-delete]: Removing finalizers from %s %s\n", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName()))
 
@@ -130,4 +129,3 @@ func handlerRemoveScAndSecretsOnModuleDelete(ctx context.Context, input *pkg.Hoo
 
 	return resultErr
 }
-

--- a/hooks/go/060-migrate-from-ceph-csi-module/migrate-from-ceph-csi-module.go
+++ b/hooks/go/060-migrate-from-ceph-csi-module/migrate-from-ceph-csi-module.go
@@ -55,7 +55,7 @@ const (
 	DiscardMountOption = "discard"
 
 	CephFSDefaultPool = "cephfs_data"
-    prometheusOperatorNamespace = "d8-operator-prometheus"
+	prometheusOperatorNamespace = "d8-operator-prometheus"
 	prometheusOperatorDeploymentName = "prometheus-operator"
 )
 

--- a/hooks/go/060-migrate-from-ceph-csi-module/migrate-from-ceph-csi-module.go
+++ b/hooks/go/060-migrate-from-ceph-csi-module/migrate-from-ceph-csi-module.go
@@ -141,7 +141,7 @@ func handlerMigrateFromCephCsiModule(ctx context.Context, _ *pkg.HookInput) erro
 		}
 
 		if !scalePrometheusOperatorUp {
-			err = funcs.ScaleDeployment(ctx, cl, prometheusOperatorNamespace, prometheusOperatorDeploymentName, &[]int32{0}[0])			
+			err = funcs.ScaleDeployment(ctx, cl, prometheusOperatorNamespace, prometheusOperatorDeploymentName, &[]int32{0}[0])
 			if err == nil {
 				scalePrometheusOperatorUp = true
 			}
@@ -293,7 +293,7 @@ func handlerMigrateFromCephCsiModule(ctx context.Context, _ *pkg.HookInput) erro
 
 	if scalePrometheusOperatorUp {
 		_ = funcs.ScaleDeployment(ctx, cl, prometheusOperatorNamespace, prometheusOperatorDeploymentName, &[]int32{1}[0])
-		}
+	}
 
 	return nil
 }

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -563,15 +563,16 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 				pvList := &v1.PersistentVolumeList{}
 
 				err = cl.List(ctx, pvList)
+				if err != nil {
+					fmt.Printf("[%s]: PVList get error %s\n", logPrefix, err)
+					return false, err
+				}
+
 				for _, pv := range pvList.Items {
 					if pv.Name == newPV.Name {
 						fmt.Printf("[%s]: Waiting for PV %s to be deleted\n", logPrefix, newPV.Name)
 						return false, nil
 					}
-				}
-				if err != nil {
-					fmt.Printf("[%s]: PVList get error %s\n", logPrefix, err)
-					return false, err
 				}
 
 				fmt.Printf("[%s]: PersistentVolume %s deleted\n", logPrefix, newPV.Name)

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -543,7 +543,6 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 			newPV.ResourceVersion = ""
 			newPV.UID = ""
 			newPV.CreationTimestamp = metav1.Time{}
-			newPV.ObjectMeta.ResourceVersion = ""
 			newPV.Spec.CSI.NodeStageSecretRef.Namespace = ModuleNamespace
 			newPV.Spec.CSI.NodeStageSecretRef.Name = newSecretName
 			newPV.Spec.CSI.ControllerExpandSecretRef.Namespace = ModuleNamespace
@@ -563,6 +562,7 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 			}
 
 			err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+				newPV.ObjectMeta.ResourceVersion = ""
 				err = cl.Create(ctx, newPV)
 				if err != nil {
 					if apierrors.IsAlreadyExists(err) {

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -566,6 +566,7 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 				err = cl.Create(ctx, newPV)
 				if err != nil {
 					if apierrors.IsAlreadyExists(err) {
+						fmt.Printf("[%s]: Waiting for PersistentVolume %s to be deleted\n", logPrefix, newPV.Name)
 						return false, nil
 					}
 

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -728,9 +728,9 @@ func setRecreateLabelToBackupResource(ctx context.Context, cl client.Client, bac
 	return nil
 }
 
-func ScaleDeployment(ctx context.Context, cl client.Client, Namespace, DeploymentName string, replicas *int32) error {
+func ScaleDeployment(ctx context.Context, cl client.Client, namespace, deploymentName string, replicas *int32) error {
 	deployment := &appsv1.Deployment{}
-	err := cl.Get(ctx, client.ObjectKey{Namespace: Namespace, Name: DeploymentName}, deployment)
+	err := cl.Get(ctx, client.ObjectKey{Namespace: namespace, Name: deploymentName}, deployment)
 	if err != nil {
 		fmt.Printf("Cannot get prometheus-operator deployment: %s\n", err.Error())
 		return err
@@ -738,7 +738,6 @@ func ScaleDeployment(ctx context.Context, cl client.Client, Namespace, Deploymen
 
 	fmt.Printf("Scaling prometheus-operator deployment replicas down\n")
 	deployment.Spec.Replicas = replicas
-	//&[]int32{0}[0]
 	err = cl.Update(ctx, deployment)
 	if err != nil {
 		fmt.Printf("Cannot update prometheus-operator deployment: %s\n", err.Error())

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -599,8 +599,8 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 			if err != nil {
 				if client.IgnoreAlreadyExists(err) == nil {
 					// If PV already exists, we need to return reclaim policy to original value
-					pathJSON := fmt.Sprintf(`{"spec":{"persistentVolumeReclaimPolicy":"%s"}}`, newPV.Spec.PersistentVolumeReclaimPolicy)
-					patch := client.RawPatch(types.MergePatchType, []byte(pathJSON))
+					patchJSON := fmt.Sprintf(`{"spec":{"persistentVolumeReclaimPolicy":"%s"}}`, newPV.Spec.PersistentVolumeReclaimPolicy)
+					patch := client.RawPatch(types.MergePatchType, []byte(patchJSON))
 					err = cl.Patch(ctx, newPV, patch)
 					if err != nil {
 						fmt.Printf("[%s]: PV patch error %s\n", logPrefix, err)

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -562,6 +562,8 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 			}
 
 			err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+				fmt.Printf("[%s]: Waiting for PersistentVolume %s to be created\n", logPrefix, newPV.Name)
+
 				newPV.ResourceVersion = ""
 				err = cl.Create(ctx, newPV)
 				if err != nil {
@@ -578,8 +580,8 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 					return false, err
 				}
 
-				fmt.Printf("[%s]: Waiting for PersistentVolume %s to be created\n", logPrefix, newPV.Name)
-				return false, nil
+				fmt.Printf("[%s]: PersistentVolume %s created\n", logPrefix, newPV.Name)
+				return true, nil
 			})
 
 			if err != nil {

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -561,7 +561,7 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 				return err
 			}
 
-			err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+			err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 				pv := &v1.PersistentVolume{}
 				
 				err := cl.Get(ctx, client.ObjectKey{Name: newPV.Name}, pv)

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -561,7 +561,7 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 				return err
 			}
 
-			err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+			err = wait.PollUntilContextTimeout(ctx, 15*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 				pv := &v1.PersistentVolume{}
 				
 				err := cl.Get(ctx, client.ObjectKey{Name: newPV.Name}, pv)

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -559,7 +559,7 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 				return err
 			}
 
-			err = wait.PollUntilContextTimeout(ctx, 30*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+			err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
 				pvList := &v1.PersistentVolumeList{}
 
 				err = cl.List(ctx, pvList)

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -559,7 +559,7 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 				return err
 			}
 
-			err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+			err = wait.PollUntilContextTimeout(ctx, 15*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 				pvList := &v1.PersistentVolumeList{}
 
 				err = cl.List(ctx, pvList)

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -562,7 +562,7 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 			}
 
 			err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
-				newPV.ObjectMeta.ResourceVersion = ""
+				newPV.ResourceVersion = ""
 				err = cl.Create(ctx, newPV)
 				if err != nil {
 					if apierrors.IsAlreadyExists(err) {

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -571,6 +571,7 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 				for _, pvItem := range pvList.Items {
 					if pvItem.Name == newPV.Name {
 						fmt.Printf("[%s]: Waiting for PV %s to be deleted\n", logPrefix, newPV.Name)
+						fmt.Printf("[%s]: PV %s still exists: %+v\n", logPrefix, newPV.Name, pvItem)
 						return false, nil
 					}
 				}

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -571,11 +571,6 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 				for _, pvItem := range pvList.Items {
 					if pvItem.Name == newPV.Name {
 						fmt.Printf("[%s]: Waiting for PV %s to be deleted\n", logPrefix, newPV.Name)
-						err = cl.Delete(ctx, pv)
-						if err != nil {
-							fmt.Printf("[%s]: PV delete error %s\n", logPrefix, err)
-						}
-	
 						return false, nil
 					}
 				}

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -559,6 +559,14 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 				return err
 			}
 
+			checkPV := &v1.PersistentVolume{}
+			for {
+				err = cl.Get(ctx, types.NamespacedName{Name: pv.Name}, checkPV)
+				if err != nil {
+					break
+				}
+			}
+
 			err = cl.Create(ctx, newPV)
 			if err != nil {
 				fmt.Printf("[%s]: PV create error %s\n", logPrefix, err)

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -572,6 +572,13 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 					if pvItem.Name == newPV.Name {
 						fmt.Printf("[%s]: Waiting for PV %s to be deleted\n", logPrefix, newPV.Name)
 						fmt.Printf("[%s]: PV %s still exists: %+v\n", logPrefix, newPV.Name, pvItem)
+						// remove finalizers
+						patch := client.RawPatch(types.MergePatchType, []byte(`{"metadata":{"finalizers":[]}}`))
+						err = cl.Patch(ctx, &pvItem, patch)
+						if err != nil {
+							fmt.Printf("[%s]: PV patch error %s\n", logPrefix, err)
+							return false, err
+						}
 						return false, nil
 					}
 				}

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -559,7 +559,7 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 				return err
 			}
 
-			err = wait.PollUntilContextTimeout(ctx, 15*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+			err = wait.PollUntilContextTimeout(ctx, 30*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
 				pvList := &v1.PersistentVolumeList{}
 
 				err = cl.List(ctx, pvList)

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -31,8 +31,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	sv1 "k8s.io/api/storage/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
@@ -568,12 +568,12 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 					if errors.IsNotFound(err) {
 						return true, nil
 					}
-					
+
 					fmt.Printf("[%s]: PersistentVolume get error %s\n", logPrefix, err)
 					return false, err					
 				}
 					
-				fmt.Printf("[%s]: Waiting for PersistentVolume %s to be released\n", logPrefix, newPV.Name)
+				fmt.Printf("[%s]: Waiting for PersistentVolume %s to be deleted\n", logPrefix, newPV.Name)
 				return false, nil
 			})
 

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -590,6 +590,11 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 				return true, nil
 			})
 
+			if err != nil {
+				fmt.Printf("[%s]: error while waiting PersistentVolume deleting %s\n", logPrefix, err)
+				return err
+			}
+
 			err = cl.Create(ctx, newPV)
 			if err != nil {
 				if client.IgnoreAlreadyExists(err) == nil {

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -543,6 +543,7 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 			newPV.ResourceVersion = ""
 			newPV.UID = ""
 			newPV.CreationTimestamp = metav1.Time{}
+			newPV.ObjectMeta.ResourceVersion = ""
 			newPV.Spec.CSI.NodeStageSecretRef.Namespace = ModuleNamespace
 			newPV.Spec.CSI.NodeStageSecretRef.Name = newSecretName
 			newPV.Spec.CSI.ControllerExpandSecretRef.Namespace = ModuleNamespace

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -589,9 +589,9 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 					err = cl.Patch(ctx, newPV, patch)
 					if err != nil {
 						fmt.Printf("[%s]: PV patch error %s\n", logPrefix, err)
-						// join error message
 						err = fmt.Errorf("failed to patch PV %s: %w", newPV.Name, err)
 					}
+				}
 				fmt.Printf("[%s]: PV create error %s\n", logPrefix, err)
 				return err
 			}

--- a/hooks/go/funcs/funcs.go
+++ b/hooks/go/funcs/funcs.go
@@ -568,9 +568,14 @@ func MigratePVsToNewSecret(ctx context.Context, cl client.Client, pvList *v1.Per
 					return false, err
 				}
 
-				for _, pv := range pvList.Items {
-					if pv.Name == newPV.Name {
+				for _, pvItem := range pvList.Items {
+					if pvItem.Name == newPV.Name {
 						fmt.Printf("[%s]: Waiting for PV %s to be deleted\n", logPrefix, newPV.Name)
+						err = cl.Delete(ctx, pv)
+						if err != nil {
+							fmt.Printf("[%s]: PV delete error %s\n", logPrefix, err)
+						}
+	
 						return false, nil
 					}
 				}

--- a/images/csi-ceph/werf.inc.yaml
+++ b/images/csi-ceph/werf.inc.yaml
@@ -7,11 +7,13 @@ final: false
 git:
   - add: /
     to: /src
+    includePaths:
+      - images/{{ $.ImageName }}
     stageDependencies:
       install:
-        - "**/*"
-    includePaths:
-      - images/csi-ceph/patches
+        - '**/*'
+    excludePaths:
+      - images/{{ $.ImageName }}/werf.yaml
 
 shell:
   install:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add prometheus operator scale in migration process, and fix migration hook

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct migration hook work

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
