### PR TITLE
Scheduled CVE scan

### DIFF
--- a/.github/workflows/trivy_image_check.yaml
+++ b/.github/workflows/trivy_image_check.yaml
@@ -11,16 +11,16 @@ on:
   workflow_dispatch:
     inputs:
       release_branch:
-        description: "release branch name, example: release-1.68"
+        description: 'Optional. Set minor version of release you want to scan. e.g.: 1.23'
         required: false
       scan_several_lastest_releases:
-        description: 'true/false. whether to scan last several releases or not. For scheduled pipelines it is always true'
+        description: 'Optional. Whether to scan last several releases or not. true/false. For scheduled pipelines it is always true. Default is: false.'
         required: false
       latest_releases_amount:
-        description: 'Number of latest releases to scan. Default is: 3'
+        description: 'Optional. Number of latest releases to scan. Default is: 3'
         required: false
       severity:
-        description: 'Vulnerabilities severity to scan. Default is: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
+        description: 'Optional. Vulnerabilities severity to scan. Default is: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
         required: false
 
 jobs:

--- a/.github/workflows/trivy_image_check.yaml
+++ b/.github/workflows/trivy_image_check.yaml
@@ -2,7 +2,7 @@ name: Build and checks
 
 on:
   schedule:
-    - cron: '0 23 * * 0,3'
+    - cron: '0 01 * * 0,3'
       scan_three_last_releases: 'true'
   pull_request:
     types: [opened, reopened, labeled, synchronize]
@@ -15,7 +15,7 @@ on:
         description: "release branch name, example: release-1.68"
         required: false
       scan_three_last_releases:
-        description: 'true/false. whether to scan last 3 releases or not. useful for scheduled task'
+        description: 'true/false. whether to scan last 3 releases or not. useful for scheduled pipeline'
         required: false
 
 jobs:

--- a/.github/workflows/trivy_image_check.yaml
+++ b/.github/workflows/trivy_image_check.yaml
@@ -37,9 +37,12 @@ jobs:
           module_name: ${{ vars.MODULE_NAME }}
           dd_url: ${{ secrets.DEFECTDOJO_HOST }}
           dd_token: ${{ secrets.DEFECTDOJO_API_TOKEN }}
-          prod_registry: ${{ vars.PROD_REGISTRY }}
+          prod_registry: registry.deckhouse.io
           prod_registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
           prod_registry_password: ${{ secrets.PROD_MODULES_READ_REGISTRY_PASSWORD }}
+          dev_registry: ${{ vars.DEV_REGISTRY }}
+          dev_registry_user: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
+          dev_registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
           deckhouse_private_repo: ${{ secrets.DECKHOUSE_PRIVATE_REPO }}
   cve_scan:
     if: github.event_name != 'pull_request'
@@ -58,7 +61,7 @@ jobs:
           module_name: ${{ vars.MODULE_NAME }}
           dd_url: ${{ secrets.DEFECTDOJO_HOST }}
           dd_token: ${{ secrets.DEFECTDOJO_API_TOKEN }}
-          prod_registry: ${{ vars.PROD_REGISTRY }}
+          prod_registry: registry.deckhouse.io
           prod_registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
           prod_registry_password: ${{ secrets.PROD_MODULES_READ_REGISTRY_PASSWORD }}
           dev_registry: ${{ vars.DEV_REGISTRY }}

--- a/.github/workflows/trivy_image_check.yaml
+++ b/.github/workflows/trivy_image_check.yaml
@@ -37,8 +37,8 @@ jobs:
           module_name: ${{ vars.MODULE_NAME }}
           dd_url: ${{ secrets.DEFECTDOJO_HOST }}
           dd_token: ${{ secrets.DEFECTDOJO_API_TOKEN }}
-          prod_registry: registry.deckhouse.io
-          prod_registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
+          prod_registry: "registry.deckhouse.io"
+          prod_registry_user: "license-token"
           prod_registry_password: ${{ secrets.PROD_MODULES_READ_REGISTRY_PASSWORD }}
           dev_registry: ${{ vars.DEV_REGISTRY }}
           dev_registry_user: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
@@ -61,8 +61,8 @@ jobs:
           module_name: ${{ vars.MODULE_NAME }}
           dd_url: ${{ secrets.DEFECTDOJO_HOST }}
           dd_token: ${{ secrets.DEFECTDOJO_API_TOKEN }}
-          prod_registry: registry.deckhouse.io
-          prod_registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
+          prod_registry: "registry.deckhouse.io"
+          prod_registry_user: "license-token"
           prod_registry_password: ${{ secrets.PROD_MODULES_READ_REGISTRY_PASSWORD }}
           dev_registry: ${{ vars.DEV_REGISTRY }}
           dev_registry_user: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}

--- a/.github/workflows/trivy_image_check.yaml
+++ b/.github/workflows/trivy_image_check.yaml
@@ -1,6 +1,9 @@
 name: Build and checks
 
 on:
+  schedule:
+    - cron: '0 23 * * 0,3'
+      scan_three_last_releases: 'true'
   pull_request:
     types: [opened, reopened, labeled, synchronize]
   push:
@@ -11,6 +14,27 @@ on:
       release_branch:
         description: "release branch name, example: release-1.68"
         required: false
+      prod_registry:
+        description: 'must be deckhouse prod registry, used to get trivy databases and release images'
+        required: true
+      prod_registry_user:
+        description: 'username to log in to deckhouse prod registry'
+        required: true
+      prod_registry_password:
+        description: 'password to log in to deckhouse prod registry'
+        required: true
+      dev_registry:
+        description: ' must be deckhouse dev registry, used to get dev images'
+        required: true
+      dev_registry_user:
+        description: 'username to log in to deckhouse dev registry'
+        required: true
+      dev_registry_password:
+        description: 'password to log in to deckhouse dev registry'
+        required: true
+      scan_three_last_releases:
+        description: 'true/false. whether to scan last 3 releases or not. useful for scheduled task'
+        required: true
 
 jobs:
   build_dev:
@@ -19,25 +43,25 @@ jobs:
     secrets: inherit
   cve_scan_on_pr:
     if: github.event_name == 'pull_request'
-    name: Trivy images check
+    name: CVE scan for PR
     runs-on: [self-hosted, regular]
     needs: [build_dev]
     steps:
       - uses: actions/checkout@v4
-      - uses: deckhouse/modules-actions/cve_scan@main
+      - uses: deckhouse/modules-actions/cve_scan@chore/cve_scheduled_scan
         with:
           image: ${{ vars.DEV_MODULE_SOURCE }}/${{ vars.MODULE_NAME }}
           tag: pr${{ github.event.number }}
           module_name: ${{ vars.MODULE_NAME }}
-          dd_url: ${{secrets.DEFECTDOJO_HOST}}
-          dd_token: ${{secrets.DEFECTDOJO_API_TOKEN}}
-          trivy_registry: ${{ vars.PROD_REGISTRY }}
-          trivy_registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
-          trivy_registry_password: ${{ secrets.PROD_MODULES_READ_REGISTRY_PASSWORD }}
-          deckhouse_private_repo: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
+          dd_url: ${{ secrets.DEFECTDOJO_HOST }}
+          dd_token: ${{ secrets.DEFECTDOJO_API_TOKEN }}
+          prod_registry: ${{ vars.PROD_REGISTRY }}
+          prod_registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
+          prod_registry_password: ${{ secrets.PROD_MODULES_READ_REGISTRY_PASSWORD }}
+          deckhouse_private_repo: ${{ secrets.DECKHOUSE_PRIVATE_REPO }}
   cve_scan:
     if: github.event_name != 'pull_request'
-    name: Trivy images check
+    name: Regular CVE scan
     runs-on: [self-hosted, regular]
     steps:
       - uses: actions/checkout@v4
@@ -45,14 +69,18 @@ jobs:
         run: |
           echo "MODULE_IMAGE_TAG=${{ github.event.inputs.release_branch || 'main' }}" >> $GITHUB_ENV
         if: github.event_name != 'workflow_dispatch'
-      - uses: deckhouse/modules-actions/cve_scan@main
+      - uses: deckhouse/modules-actions/cve_scan@chore/cve_scheduled_scan
         with:
           image: ${{ vars.DEV_MODULE_SOURCE }}/${{ vars.MODULE_NAME }}
           tag: ${{ env.MODULE_IMAGE_TAG || 'main' }}
           module_name: ${{ vars.MODULE_NAME }}
-          dd_url: ${{secrets.DEFECTDOJO_HOST}}
-          dd_token: ${{secrets.DEFECTDOJO_API_TOKEN}}
-          trivy_registry: ${{ vars.PROD_REGISTRY }}
-          trivy_registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
-          trivy_registry_password: ${{ secrets.PROD_MODULES_READ_REGISTRY_PASSWORD }}
-          deckhouse_private_repo: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
+          dd_url: ${{ secrets.DEFECTDOJO_HOST }}
+          dd_token: ${{ secrets.DEFECTDOJO_API_TOKEN }}
+          prod_registry: ${{ vars.PROD_REGISTRY }}
+          prod_registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
+          prod_registry_password: ${{ secrets.PROD_MODULES_READ_REGISTRY_PASSWORD }}
+          dev_registry: ${{ vars.DEV_REGISTRY }}
+          dev_registry_user: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
+          dev_registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
+          deckhouse_private_repo: ${{ secrets.DECKHOUSE_PRIVATE_REPO }}
+          scan_three_last_releases: ${{ github.event.schedule.scan_three_last_releases || github.event.inputs.scan_three_last_releases }}

--- a/.github/workflows/trivy_image_check.yaml
+++ b/.github/workflows/trivy_image_check.yaml
@@ -14,27 +14,9 @@ on:
       release_branch:
         description: "release branch name, example: release-1.68"
         required: false
-      prod_registry:
-        description: 'must be deckhouse prod registry, used to get trivy databases and release images'
-        required: true
-      prod_registry_user:
-        description: 'username to log in to deckhouse prod registry'
-        required: true
-      prod_registry_password:
-        description: 'password to log in to deckhouse prod registry'
-        required: true
-      dev_registry:
-        description: ' must be deckhouse dev registry, used to get dev images'
-        required: true
-      dev_registry_user:
-        description: 'username to log in to deckhouse dev registry'
-        required: true
-      dev_registry_password:
-        description: 'password to log in to deckhouse dev registry'
-        required: true
       scan_three_last_releases:
         description: 'true/false. whether to scan last 3 releases or not. useful for scheduled task'
-        required: true
+        required: false
 
 jobs:
   build_dev:

--- a/.github/workflows/trivy_image_check.yaml
+++ b/.github/workflows/trivy_image_check.yaml
@@ -37,7 +37,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: deckhouse/modules-actions/cve_scan@chore/cve_scheduled_scan
         with:
-          image: ${{ vars.DEV_MODULE_SOURCE }}/${{ vars.MODULE_NAME }}
           tag: pr${{ github.event.number }}
           module_name: ${{ vars.MODULE_NAME }}
           dd_url: ${{ secrets.DEFECTDOJO_HOST }}
@@ -58,7 +57,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: deckhouse/modules-actions/cve_scan@chore/cve_scheduled_scan
         with:
-          image: ${{ vars.DEV_MODULE_SOURCE }}/${{ vars.MODULE_NAME }}
           tag: ${{ github.event.inputs.release_branch || github.event.repository.default_branch }}
           module_name: ${{ vars.MODULE_NAME }}
           dd_url: ${{ secrets.DEFECTDOJO_HOST }}
@@ -71,5 +69,5 @@ jobs:
           dev_registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
           deckhouse_private_repo: ${{ secrets.DECKHOUSE_PRIVATE_REPO }}
           scan_several_lastest_releases: ${{ github.event.inputs.scan_several_lastest_releases }}
-          latest_releases_amount: ${{ github.event.inputs.latest_releases_amount }}
+          latest_releases_amount: ${{ github.event.inputs.latest_releases_amount || '3' }}
           severity: ${{ github.event.inputs.severity }}

--- a/.github/workflows/trivy_image_check.yaml
+++ b/.github/workflows/trivy_image_check.yaml
@@ -3,7 +3,6 @@ name: Build and checks
 on:
   schedule:
     - cron: '0 01 * * 0,3'
-      scan_three_last_releases: 'true'
   pull_request:
     types: [opened, reopened, labeled, synchronize]
   push:
@@ -14,8 +13,14 @@ on:
       release_branch:
         description: "release branch name, example: release-1.68"
         required: false
-      scan_three_last_releases:
-        description: 'true/false. whether to scan last 3 releases or not. useful for scheduled pipeline'
+      scan_several_lastest_releases:
+        description: 'true/false. whether to scan last several releases or not. For scheduled pipelines it is always true'
+        required: false
+      latest_releases_amount:
+        description: 'Number of latest releases to scan. Default is: 3'
+        required: false
+      severity:
+        description: 'Vulnerabilities severity to scan. Default is: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
         required: false
 
 jobs:
@@ -44,20 +49,17 @@ jobs:
           dev_registry_user: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
           dev_registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
           deckhouse_private_repo: ${{ secrets.DECKHOUSE_PRIVATE_REPO }}
+          severity: "HIGH,CRITICAL"
   cve_scan:
     if: github.event_name != 'pull_request'
     name: Regular CVE scan
     runs-on: [self-hosted, regular]
     steps:
       - uses: actions/checkout@v4
-      - name: Sets env vars for manual run
-        run: |
-          echo "MODULE_IMAGE_TAG=${{ github.event.inputs.release_branch || 'main' }}" >> $GITHUB_ENV
-        if: github.event_name != 'workflow_dispatch'
       - uses: deckhouse/modules-actions/cve_scan@chore/cve_scheduled_scan
         with:
           image: ${{ vars.DEV_MODULE_SOURCE }}/${{ vars.MODULE_NAME }}
-          tag: ${{ env.MODULE_IMAGE_TAG || 'main' }}
+          tag: ${{ github.event.inputs.release_branch || github.event.repository.default_branch }}
           module_name: ${{ vars.MODULE_NAME }}
           dd_url: ${{ secrets.DEFECTDOJO_HOST }}
           dd_token: ${{ secrets.DEFECTDOJO_API_TOKEN }}
@@ -68,4 +70,6 @@ jobs:
           dev_registry_user: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
           dev_registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
           deckhouse_private_repo: ${{ secrets.DECKHOUSE_PRIVATE_REPO }}
-          scan_three_last_releases: ${{ github.event.schedule.scan_three_last_releases || github.event.inputs.scan_three_last_releases }}
+          scan_several_lastest_releases: ${{ github.event.inputs.scan_several_lastest_releases }}
+          latest_releases_amount: ${{ github.event.inputs.latest_releases_amount }}
+          severity: ${{ github.event.inputs.severity }}

--- a/.github/workflows/trivy_image_check.yaml
+++ b/.github/workflows/trivy_image_check.yaml
@@ -35,7 +35,7 @@ jobs:
     needs: [build_dev]
     steps:
       - uses: actions/checkout@v4
-      - uses: deckhouse/modules-actions/cve_scan@chore/cve_scheduled_scan
+      - uses: deckhouse/modules-actions/cve_scan@v3
         with:
           tag: pr${{ github.event.number }}
           module_name: ${{ vars.MODULE_NAME }}
@@ -55,7 +55,7 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
       - uses: actions/checkout@v4
-      - uses: deckhouse/modules-actions/cve_scan@chore/cve_scheduled_scan
+      - uses: deckhouse/modules-actions/cve_scan@v3
         with:
           tag: ${{ github.event.inputs.release_branch || github.event.repository.default_branch }}
           module_name: ${{ vars.MODULE_NAME }}

--- a/.github/workflows/trivy_image_check.yaml
+++ b/.github/workflows/trivy_image_check.yaml
@@ -71,3 +71,4 @@ jobs:
           scan_several_lastest_releases: ${{ github.event.inputs.scan_several_lastest_releases }}
           latest_releases_amount: ${{ github.event.inputs.latest_releases_amount || '3' }}
           severity: ${{ github.event.inputs.severity }}
+


### PR DESCRIPTION
## Description
- Schedule to scan main and 3 latest releases of module
- Ability to manually run scan of main and 3 latest releases of module

## Why do we need it, and what problem does it solve?
We need to regularly scan cve on main and 3 latest releases 

## What is the expected result?
Run CVE scan pipeline manually to scan any branch and optionally set to scan 3 latest releases

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
