### PR TITLE
[controller][docs] Fix docs and cis-node templates

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -15,30 +15,14 @@ spec:
   - 172.20.1.28:6789
   - 172.20.1.34:6789
   - 172.20.1.37:6789
-```
-
-- To verify the creation of the object, use the following command (Phase should be `Created`):
-
-```shell
-kubectl get cephclusterconnection <cephclusterconnection name>
-```
-
-## Example of `CephClusterAuthentication`
-
-```yaml
-apiVersion: storage.deckhouse.io/v1alpha1
-kind: CephClusterAuthentication
-metadata:
-  name: ceph-auth-1
-spec:
-  userID: user
+  userID: admin
   userKey: AQDiVXVmBJVRLxAAg65PhODrtwbwSWrjJwssUg==
 ```
 
 - To verify the creation of the object, use the following command (Phase should be `Created`):
 
 ```shell
-kubectl get cephclusterauthentication <cephclusterauthentication name>
+kubectl get cephclusterconnection <cephclusterconnection name>
 ```
 
 ## Example of `CephStorageClass` configuration
@@ -52,7 +36,6 @@ metadata:
   name: ceph-rbd-sc
 spec:
   clusterConnectionName: ceph-cluster-1
-  clusterAuthenticationName: ceph-auth-1
   reclaimPolicy: Delete
   type: RBD
   rbd:
@@ -69,7 +52,6 @@ metadata:
   name: ceph-fs-sc
 spec:
   clusterConnectionName: ceph-cluster-1
-  clusterAuthenticationName: ceph-auth-1
   reclaimPolicy: Delete
   type: CephFS
   cephFS:

--- a/docs/EXAMPLES_RU.md
+++ b/docs/EXAMPLES_RU.md
@@ -15,29 +15,14 @@ spec:
   - 172.20.1.28:6789
   - 172.20.1.34:6789
   - 172.20.1.37:6789
-```
-
-- Проверить создание объекта можно командой (Phase должен быть `Created`):
-
-```shell
-kubectl get cephclusterconnection <имя cephclusterconnection>
-```
-## Пример описания `CephClusterAuthentication`
-
-```yaml
-apiVersion: storage.deckhouse.io/v1alpha1
-kind: CephClusterAuthentication
-metadata:
-  name: ceph-auth-1
-spec:
-  userID: user
+  userID: admin
   userKey: AQDiVXVmBJVRLxAAg65PhODrtwbwSWrjJwssUg==
 ```
 
 - Проверить создание объекта можно командой (Phase должен быть `Created`):
 
 ```shell
-kubectl get cephclusterauthentication <имя cephclusterauthentication>
+kubectl get cephclusterconnection <имя cephclusterconnection>
 ```
 
 ## Пример описания `CephStorageClass`
@@ -51,7 +36,6 @@ metadata:
   name: ceph-rbd-sc
 spec:
   clusterConnectionName: ceph-cluster-1
-  clusterAuthenticationName: ceph-auth-1
   reclaimPolicy: Delete
   type: RBD
   rbd:
@@ -68,7 +52,6 @@ metadata:
   name: ceph-fs-sc
 spec:
   clusterConnectionName: ceph-cluster-1
-  clusterAuthenticationName: ceph-auth-1
   reclaimPolicy: Delete
   type: CephFS
   cephFS:

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,12 @@ spec:
   # List of Ceph monitor IP addresses in the format 10.0.0.10:6789.
   monitors:
     - 10.0.0.10:6789
+  # User name without `client.`.
+  # The user name can be obtained using the `ceph auth list` command.
+  userID: admin
+  # Authentication key corresponding to the userID.
+  # The authentication key can be obtained using the `ceph auth get-key client.admin` command.
+  userKey: AQDiVXVmBJVRLxAAg65PhODrtwbwSWrjJwssUg==
 EOF
 ```
 
@@ -57,24 +63,6 @@ You can check the connection status with the following command (the `Phase` shou
 
 ```shell
 d8 k get cephclusterconnection ceph-cluster-1
-```
-
-## Authentication
-
-To authenticate with the Ceph cluster, you need to define the authentication parameters in the [CephClusterAuthentication](../../../reference/cr/cephclusterauthentication/) resource:
-
-```yaml
-d8 k apply -f - <<EOF
-apiVersion: storage.deckhouse.io/v1alpha1
-kind: CephClusterAuthentication
-metadata:
-  name: ceph-auth-1
-spec:
-  # User name without `client.`.
-  userID: admin
-  # Authentication key corresponding to the userID.
-  userKey: AQDbc7phl+eeGRAAaWL9y71mnUiRHKRFOWMPCQ==
-EOF
 ```
 
 ## Creating StorageClass
@@ -89,7 +77,6 @@ metadata:
   name: ceph-rbd-sc
 spec:
   clusterConnectionName: ceph-cluster-1
-  clusterAuthenticationName: ceph-auth-1
   reclaimPolicy: Delete
   type: RBD
   rbd:
@@ -108,7 +95,6 @@ metadata:
   name: ceph-fs-sc
 spec:
   clusterConnectionName: ceph-cluster-1
-  clusterAuthenticationName: ceph-auth-1
   reclaimPolicy: Delete
   type: CephFS
   cephFS:

--- a/docs/README_RU.md
+++ b/docs/README_RU.md
@@ -50,6 +50,12 @@ spec:
   # Список IP-адресов ceph-mon’ов в формате 10.0.0.10:6789.
   monitors:
     - 10.0.0.10:6789
+  # Имя пользователя без `client.`.
+  # Получить имя пользователя можно с помощью команды `ceph auth list`.
+  userID: admin
+  # Ключ авторизации, соответствующий userID.
+  # Получить ключ авторизации можно с помощью команды `ceph auth get-key client.admin`.
+  userKey: AQDiVXVmBJVRLxAAg65PhODrtwbwSWrjJwssUg==
 EOF
 ```
 
@@ -57,24 +63,6 @@ EOF
 
 ```shell
 d8 k get cephclusterconnection ceph-cluster-1
-```
-
-## Аутентификация
-
-Чтобы пройти аутентификацию в Ceph-кластере, необходимо определить параметры аутентификации в ресурсе [CephClusterAuthentication](../../../reference/cr/cephclusterauthentication/):
-
-```yaml
-d8 k apply -f - <<EOF
-apiVersion: storage.deckhouse.io/v1alpha1
-kind: CephClusterAuthentication
-metadata:
-  name: ceph-auth-1
-spec:
-  # Имя пользователя без `client.`.
-  userID: admin
-  # Ключ авторизации, соответствующий userID.
-  userKey: AQDbc7phl+eeGRAAaWL9y71mnUiRHKRFOWMPCQ==
-EOF
 ```
 
 ## Создание StorageClass
@@ -89,7 +77,6 @@ metadata:
   name: ceph-rbd-sc
 spec:
   clusterConnectionName: ceph-cluster-1
-  clusterAuthenticationName: ceph-auth-1
   reclaimPolicy: Delete
   type: RBD
   rbd:
@@ -108,7 +95,6 @@ metadata:
   name: ceph-fs-sc
 spec:
   clusterConnectionName: ceph-cluster-1
-  clusterAuthenticationName: ceph-auth-1
   reclaimPolicy: Delete
   type: CephFS
   cephFS:

--- a/templates/cephfs/controller.yaml
+++ b/templates/cephfs/controller.yaml
@@ -156,6 +156,8 @@
 #   mountPath: /etc/ceph/
 - name: ceph-csi-config
   mountPath: /etc/ceph-csi-config/
+- name: keys-tmp-dir
+  mountPath: /tmp/csi/keys
 - name: tmp
   mountPath: /tmp
 {{- end }}
@@ -185,6 +187,10 @@
     items:
       - key: config.json
         path: config.json
+- name: keys-tmp-dir
+  emptyDir: {
+    medium: "Memory"
+  }
 - name: tmp
   emptyDir: {
     medium: "Memory"

--- a/templates/rbd/controller.yaml
+++ b/templates/rbd/controller.yaml
@@ -217,6 +217,8 @@ memory: 50Mi
   readOnly: true
 - name: ceph-csi-config
   mountPath: /etc/ceph-csi-config/
+- name: keys-tmp-dir
+  mountPath: /tmp/csi/keys
 - name: tmp
   mountPath: /tmp
 - name: etc-ceph-dir
@@ -245,6 +247,10 @@ memory: 50Mi
     items:
       - key: config.json
         path: config.json
+- name: keys-tmp-dir
+  emptyDir: {
+    medium: "Memory"
+  }
 - name: tmp
   emptyDir: {
     medium: "Memory"


### PR DESCRIPTION
### Description
This PR updates both the cis-node templates and documentation to correct and streamline Ceph CSI configuration.

* **Controller templates**
  * **RBD & CephFS csi-node** – added a dedicated writable directory for temporary key files:
    * New volume mount: `keys-tmp-dir` (mounted at `/tmp/csi/keys`)
    * **Why?**  The controllers create a temporary key file at `/tmp/csi/keys/<filename>`. In Deckhouse `/tmp` is mounted read-only, so the operation failed with  `error creating a temporary keyfile: open /tmp/csi/keys/...: no such file or directory`.  Even though an `emptyDir` was already mounted at `/tmp`, the nested `.../keys` path was still missing. Mounting a separate `emptyDir` exactly at `/tmp/csi/keys` guarantees a writable location and resolves the error.

* **Documentation**
  * Standardised example manifests:
    * Credentials are now shown as  
      `userID: admin` and `userKey: <BASE64-ENCODED-KEY>`
    * Removed the obsolete `clusterAuthenticationName` field.
  * Updated both English and Russian README / EXAMPLES to match the current
    CRDs and the new key-directory logic.

### What is the expected result?
- RBD and CephFS CSI nodes mount successfully and create their temporary key files in `/tmp/csi/keys` without permission errors.
- Users can deploy working `CephClusterConnection` and `CephStorageClass` resources using the updated examples.
- No references to the removed `clusterAuthenticationName` field remain in the docs.

### Checklist
- [ ] Unit tests updated/added where relevant  
- [ ] e2e tests passed  
- [x] Documentation updated  
- [x] Manually tested in a Kubernetes cluster
