### PR TITLE
[controller] Enforce CephClusterConnection spec.cephFS immutability via CEL (safe when cephFS is absent)

### DIFF
--- a/crds/cephclusterconnection.yaml
+++ b/crds/cephclusterconnection.yaml
@@ -24,8 +24,8 @@ spec:
           description: |
             Ceph cluster connection parameters.
           x-kubernetes-validations:
-            - rule: 'oldSelf == null || self.spec.cephFS == oldSelf.spec.cephFS'
-              message: "The spec.cephFS field is immutable."
+            - rule: 'oldSelf == null || (has(self.spec.cephFS) == has(oldSelf.spec.cephFS) && (!has(self.spec.cephFS) || self.spec.cephFS == oldSelf.spec.cephFS))'
+              message: "The spec.cephFS field is immutable (cannot be added, removed, or changed)."
           required:
             - spec
           properties:


### PR DESCRIPTION
## Description
- Add a robust CEL validation to the CRD to make `spec.cephFS` fully immutable (cannot be added, removed, or changed after creation).
- Use a guarded rule that handles objects without `cephFS` to avoid validation errors during controller updates:
  - Rule: `oldSelf == null || (has(self.spec.cephFS) == has(oldSelf.spec.cephFS) && (!has(self.spec.cephFS) || self.spec.cephFS == oldSelf.spec.cephFS))`
  - Message: “The spec.cephFS field is immutable (cannot be added, removed, or changed).”
- Keep `spec.cephFS.subvolumeGroup` immutability as-is.

No restarts of critical components are expected.

## Why do we need it, and what problem does it solve?
- Previous validation attempts caused reconcile failures on resources created without `spec.cephFS` when the controller tried to add a finalizer (validation referenced a missing key).
- We also want to prevent bypassing immutability by deleting the whole `cephFS` block and setting a different value later, since changing the CephFS subvolume group affects data placement/behavior.
- This change enforces the policy while ensuring resources without `cephFS` remain valid during normal controller updates.

## What is the expected result?
- Creating a CephClusterConnection without `spec.cephFS` works; the controller can add finalizers and update status without validation errors.
- Any attempt to add, remove, or modify `spec.cephFS` after creation is rejected with a clear validation message.
- If `spec.cephFS.subvolumeGroup` was set on creation, it remains immutable as before.

## Checklist
- [ ] The code is covered by unit tests. (CRD validation only; no code changes)
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.