### PR TITLE
[images] Add missing mount points for csi-ceph distroless image

### DIFF
--- a/.github/workflows/trivy_image_check.yaml
+++ b/.github/workflows/trivy_image_check.yaml
@@ -30,7 +30,6 @@ on:
 
 jobs:
   build_dev:
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/build_dev.yml
     secrets: inherit
     with:

--- a/images/csi-ceph/mount-points.yaml
+++ b/images/csi-ceph/mount-points.yaml
@@ -7,7 +7,5 @@ dirs:
   - /etc/selinux
   - /lib/modules
   - /run/mount
-  - /sys
-  - /sys/fs/cgroup
   - /tmp
   - /tmp/csi/keys

--- a/images/csi-ceph/mount-points.yaml
+++ b/images/csi-ceph/mount-points.yaml
@@ -1,8 +1,13 @@
 dirs:
   - /var/lib/kubelet
   - /csi
-  - /etc/selinux
-  - /lib/modules
+  - /dev
   - /etc/ceph/
   - /etc/ceph-csi-config/
+  - /etc/selinux
+  - /lib/modules
+  - /run/mount
+  - /sys
+  - /sys/fs/cgroup
+  - /tmp
   - /tmp/csi/keys


### PR DESCRIPTION
## Description

### 1. Missing mount points for `csi-ceph` distroless image

Several volume mount paths used by the CephFS / RBD CSI controller and node containers were not declared in `images/csi-ceph/mount-points.yaml`.

The `csi-ceph` image is built on the distroless base and the containers run with `readOnlyRootFilesystem: true`. With a read-only root filesystem the kubelet cannot create missing mount target directories at pod start, so any `volumeMount.mountPath` that is not pre-created in the image at build time will fail to mount (or render the container unable to start).

This PR adds the missing directories to `images/csi-ceph/mount-points.yaml` so that they are baked into the image:

* `/dev` — used by the controller and node containers (CephFS controller, RBD `rbdplugin`, both nodes)
* `/run/mount` — used by the CephFS and RBD node containers
* `/tmp` — used by every container that mounts an in-memory `emptyDir` at `/tmp`

The previously declared `/tmp/csi/keys` covers only that specific subpath, which is still required because both `/tmp` and `/tmp/csi/keys` are mounted as separate `emptyDir` volumes.

### 2. Regular CVE scan limitations fix (mirror of #137)

In `.github/workflows/trivy_image_check.yaml`, the `build_dev` reusable workflow now runs for every trigger of this workflow (`push` to `main`, `schedule`, `pull_request`, `workflow_dispatch`). `cve_scan` keeps `needs: [build_dev]` so the regular CVE scan runs after the dev build. Previously `build_dev` was gated by `if`, so it did not run on `push` to `main` or on `schedule`, and `cve_scan` was skipped as well.

## Why do we need it, and what problem does it solve?

This is a critical issue: as soon as the image is rebuilt on the new distroless base (or the CSI containers are restarted on a node where the directories do not already exist for some other reason), the affected pods will fail to start because the host-path / emptyDir volumes cannot be mounted onto missing directories in a read-only rootfs.

Verified with a helm-template based checker against the rendered `cephfs` and `rbd` controller / node manifests: every `volumeMounts.mountPath` on a container that uses the `csi-ceph` image is now covered by `images/csi-ceph/mount-points.yaml`.

The CI change ensures that the regular CVE scan on `push` to `main` and on the cron schedule actually runs — previously the workflow dependency chain was broken.

## What is the expected result?

After applying:

* `images/csi-ceph/mount-points.yaml` lists every directory mounted into the cephcsi containers.
* Once the image is rebuilt and rolled out, the CephFS and RBD controller / node pods start successfully on a node that does not have these paths preexisting in the container rootfs.
* `build_dev` runs on `push` to `main` and on the cron schedule, and `cve_scan` runs after it.

No template / runtime behaviour is intentionally changed — this is purely an image build-time + CI change.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
