### PR TITLE
fix(CI): regular CVE scan limitations fix

### DIFF
--- a/.github/workflows/trivy_image_check.yaml
+++ b/.github/workflows/trivy_image_check.yaml
@@ -30,7 +30,6 @@ on:
 
 jobs:
   build_dev:
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/build_dev.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Description
In `.github/workflows/trivy_image_check.yaml`, the `build_dev` reusable workflow now runs for every trigger of this workflow (`push` to `main`, `schedule`, `pull_request`, `workflow_dispatch`). `cve_scan` again has `needs: [build_dev]` so the regular CVE scan runs after the dev build.
## Why do we need it, and what problem does it solve?
Previously `build_dev` was gated by `if`, so it did not run on `push` to `main` or on `schedule`, while `cve_scan` depended on it and was skipped as well. The scan flow expects the dev build (registry/artifacts) to exist first.
## What is the expected result?
After merge: on `push` to `main` and on the cron schedule, `build_dev` runs and then `cve_scan`; on pull requests, `build_dev` still runs before `cve_scan_on_pr`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
