### PR TITLE
[ci] Add role_name to cve_scan actions

### DIFF
--- a/.github/workflows/trivy_image_check.yaml
+++ b/.github/workflows/trivy_image_check.yaml
@@ -74,6 +74,7 @@ jobs:
             projects/data/b050f3bd-733f-4746-9640-9df80d484074/CODEOWNERS_REPO_TOKEN CODEOWNERS_REPO_TOKEN | CODEOWNERS_REPO_TOKEN ;
       - uses: deckhouse/modules-actions/cve_scan@v11
         with:
+          role_name: csi-ceph
           source_tag: 'pr${{ github.event.number }}'
           case: "External Modules"
           external_module_name: ${{ vars.MODULE_NAME }}
@@ -130,6 +131,7 @@ jobs:
             projects/data/b050f3bd-733f-4746-9640-9df80d484074/CODEOWNERS_REPO_TOKEN CODEOWNERS_REPO_TOKEN | CODEOWNERS_REPO_TOKEN ;
       - uses: deckhouse/modules-actions/cve_scan@main
         with:
+          role_name: csi-ceph
           source_tag: ${{ github.event.inputs.release_branch || github.event.repository.default_branch }}
           case: "External Modules"
           external_module_name: ${{ vars.MODULE_NAME }}


### PR DESCRIPTION
## Description

Add `role_name: csi-ceph` parameter to both `cve_scan` action invocations in `.github/workflows/trivy_image_check.yaml`:

- `cve_scan_on_pr` job — `deckhouse/modules-actions/cve_scan@v11` (CVE scan on pull request).
- `cve_scan` job — `deckhouse/modules-actions/cve_scan@main` (regular/scheduled CVE scan).

The value is the module repository name (`csi-ceph`).

## Why do we need it, and what problem does it solve?

The `cve_scan` action expects the module name to be passed explicitly via the new `role_name` input so that scan results are correctly attributed to the module.

## What is the expected result?

The Trivy CVE scan workflow (`Build and checks`) keeps working as before; both the PR scan job and the scheduled scan job now pass `role_name: csi-ceph` to the `cve_scan` action.

## Checklist

- [ ] The code is covered by unit tests. <!-- N/A — CI-only change -->
- [ ] e2e tests passed. <!-- N/A — CI-only change -->
- [ ] Documentation updated according to the changes. <!-- N/A — CI-only change -->
- [ ] Changes were tested in the Kubernetes cluster manually. <!-- N/A — CI-only change -->