### PR TITLE
fix(monitoring): correct PromQL in storage class PrometheusRules

### DIFF
--- a/crds/doc-ru-cephmetadatabackup.yaml
+++ b/crds/doc-ru-cephmetadatabackup.yaml
@@ -1,0 +1,13 @@
+spec:
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |
+            CephMetadataBackup — пользовательский ресурс Kubernetes, хранящий резервную копию ресурсов Kubernetes.
+          properties:
+            spec:
+              properties:
+                data:
+                  description: |
+                    Ресурс Kubernetes в кодировке base64.

--- a/monitoring/prometheus-rules/storage-class.yaml
+++ b/monitoring/prometheus-rules/storage-class.yaml
@@ -1,7 +1,7 @@
-- name: kubernetes.replicated.storage_class
+- name: kubernetes.ceph.storage_class
   rules:
     - alert: StorageClassNewCephClusterConnectionCreated
-      expr: sum(kube_storageclass_info{provisioner=~"cephfs.csi.ceph.com|rbd.csi.ceph.com"} * on(storageclass) group_left() kube_storageclass_labels{"storage.deckhouse.io/migratedFromCephClusterAuthenticationWarning"="true"}) > 0
+      expr: sum(kube_storageclass_info{provisioner=~"cephfs.csi.ceph.com|rbd.csi.ceph.com"} * on(storageclass) group_left() kube_storageclass_labels{label_storage_deckhouse_io_migratedFromCephClusterAuthenticationWarning="true"}) > 0
       for: 5m
       labels:
         severity_level: "6"
@@ -20,7 +20,7 @@
           `kubectl label storageclass --all storage.deckhouse.io/migratedFromCephClusterAuthenticationWarning-`
           
     - alert: StorageClassCephClusterAuthenticationNotMigrated
-      expr: sum(kube_storageclass_info{provisioner=~"cephfs.csi.ceph.com|rbd.csi.ceph.com"} * on(storageclass) group_left() kube_storageclass_labels{"storage.deckhouse.io/migratedFromCephClusterAuthentication"="false"}) > 0
+      expr: sum(kube_storageclass_info{provisioner=~"cephfs.csi.ceph.com|rbd.csi.ceph.com"} * on(storageclass) group_left() kube_storageclass_labels{label_storage_deckhouse_io_migratedFromCephClusterAuthentication="false"}) > 0
       for: 5m
       labels:
         severity_level: "4"
@@ -39,7 +39,7 @@
           Check the Deckhouse logs and address the existing issues.
           
     - alert: StorageClassPossibleProblemWithAllowVolumeExpansion
-      expr: sum(kube_storageclass_info{provisioner=~"cephfs.csi.ceph.com|rbd.csi.ceph.com"} * on(storageclass) group_left() kube_storageclass_labels{"storage.deckhouse.io/allow-volume-expansion"="false"}) > 0
+      expr: sum(kube_storageclass_info{provisioner=~"cephfs.csi.ceph.com|rbd.csi.ceph.com"} * on(storageclass) group_left() kube_storageclass_labels{label_storage_deckhouse_io_allow_volume_expansion="false"}) > 0
       for: 5m
       labels:
         severity_level: "5"
@@ -66,7 +66,7 @@
           `kubectl label storageclass --all storage.deckhouse.io/allow-volume-expansion-`
           
     - alert: StorageClassPossibleProblemWithMountOptions
-      expr: sum(kube_storageclass_info{provisioner=~"cephfs.csi.ceph.com|rbd.csi.ceph.com"} * on(storageclass) group_left() kube_storageclass_labels{"storage.deckhouse.io/mount-options"!=""}) > 0
+      expr: sum(kube_storageclass_info{provisioner=~"cephfs.csi.ceph.com|rbd.csi.ceph.com"} * on(storageclass) group_left() kube_storageclass_labels{label_storage_deckhouse_io_mount_options!=""}) > 0
       for: 5m
       labels:
         severity_level: "5"
@@ -95,7 +95,7 @@
           `kubectl label storageclass --all storage.deckhouse.io/mount-options-`
           
     - alert: StorageClassPossibleProblemWithCephfsPool
-      expr: sum(kube_storageclass_info{provisioner=~"cephfs.csi.ceph.com|rbd.csi.ceph.com"} * on(storageclass) group_left() kube_storageclass_labels{"storage.deckhouse.io/cephfs-pool"!=""}) > 0
+      expr: sum(kube_storageclass_info{provisioner=~"cephfs.csi.ceph.com|rbd.csi.ceph.com"} * on(storageclass) group_left() kube_storageclass_labels{label_storage_deckhouse_io_cephfs_pool!=""}) > 0
       for: 5m
       labels:
         severity_level: "5"


### PR DESCRIPTION
## Description

Fix invalid PromQL expressions in `monitoring/prometheus-rules/storage-class.yaml` for the `csi-ceph-storage-class` PrometheusRule.

Changes:
- Replace invalid label selectors like `kube_storageclass_labels{"storage.deckhouse.io/..."}` with kube-state-metrics names (`label_storage_deckhouse_io_*`) in all five alert rules.
- Rename the rule group from `kubernetes.replicated.storage_class` (copied from sds-replicated-volume by mistake) to `kubernetes.ceph.storage_class`.
- Add `crds/doc-ru-cephmetadatabackup.yaml` — Russian OpenAPI descriptions for the `CephMetadataBackup` CRD (by analogy with other `doc-ru-*` CRD files).

## Why do we need it, and what problem does it solve?

Prometheus operator rejects the `csi-ceph-storage-class` PrometheusRule with parse errors (`unexpected character inside braces: '.'`) and skips the entire rule group. As a result, none of the storage class migration alerts are evaluated.

The `CephMetadataBackup` CRD had no Russian documentation overlay; other module CRDs already ship `doc-ru-*.yaml` files for the documentation UI.

## What is the expected result?

After applying the module update:
- Prometheus operator loads `csi-ceph-storage-class` without `Invalid rule` / `skipping prometheusrule` messages in logs.
- Alerts in group `kubernetes.ceph.storage_class` fire when the corresponding StorageClass labels are present (migration warnings, non-migrated auth, allow-volume-expansion, mount-options, cephfs-pool).
- In the Russian documentation, `CephMetadataBackup` fields show translated descriptions from `doc-ru-cephmetadatabackup.yaml`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.