### PR TITLE
fix(controller): reconcile CephStorageClass on labels change

### DIFF
--- a/images/controller/pkg/controller/ceph_storage_class_watcher.go
+++ b/images/controller/pkg/controller/ceph_storage_class_watcher.go
@@ -141,8 +141,10 @@ func RunCephStorageClassWatcherController(
 			oldCephSC := e.ObjectOld
 			newCephSC := e.ObjectNew
 
-			if reflect.DeepEqual(oldCephSC.Spec, newCephSC.Spec) && newCephSC.DeletionTimestamp == nil {
-				log.Info(fmt.Sprintf("[UpdateFunc] an update event for the CephStorageClass %s has no Spec field updates. It will not be reconciled", newCephSC.Name))
+			if reflect.DeepEqual(oldCephSC.Spec, newCephSC.Spec) &&
+				reflect.DeepEqual(oldCephSC.Labels, newCephSC.Labels) &&
+				newCephSC.DeletionTimestamp == nil {
+				log.Info(fmt.Sprintf("[UpdateFunc] an update event for the CephStorageClass %s has no Spec or Labels updates. It will not be reconciled", newCephSC.Name))
 				return
 			}
 


### PR DESCRIPTION
## Summary

- The watcher's `UpdateFunc` previously ignored events where only `metadata.labels` changed (it filtered out events with unchanged `Spec`).
- As a result, adding/removing labels on an existing `CephStorageClass` did not propagate to the managed `storage.k8s.io/StorageClass` until the SC was recreated.
- Now `UpdateFunc` also tracks `Labels`, so any change in `metadata.labels` on the CR enqueues a reconcile, after which the existing label-diff logic in `GetSCDiff` triggers `recreateStorageClass` with the up-to-date labels.

## Test plan

- [ ] Create a `CephStorageClass`, confirm labels appear on the managed `StorageClass`.
- [ ] Add a new label to an existing `CephStorageClass`, confirm it appears on the `StorageClass` without manual recreation.
- [ ] Remove a label from the `CephStorageClass`, confirm it is removed from the `StorageClass`.
- [ ] Confirm the `storage.deckhouse.io/managed-by` label is always preserved.