### PR TITLE
fix(charts): scope deckhouse-registry secret auths to the active image source

### DIFF
--- a/templates/registry-secret.yaml
+++ b/templates/registry-secret.yaml
@@ -13,6 +13,23 @@ data:
   .dockerconfigjson: "eyJhdXRocyI6IHsgInJlZ2lzdHJ5LmRlY2tob3VzZS5pbyI6IHt9fX0="
 {{- end }}
 ---
+{{- $moduleDockercfg := dig "registry" "dockercfg" "" .Values.csiCeph }}
+{{- $globalDockercfg := .Values.global.modulesImages.registry.dockercfg }}
+{{- /* This module and storage-foundation always share the same registry source, so the
+       module dockercfg already authenticates storage-foundation images. The DKP
+       (global) registry auth is only needed for the common CSI sidecars, i.e.
+       when storage-foundation is disabled. */}}
+{{- $baseDockercfg := $globalDockercfg }}
+{{- if and (.Values.global.enabledModules | has "storage-foundation") $moduleDockercfg }}
+  {{- $baseDockercfg = $moduleDockercfg }}
+{{- end }}
+{{- $baseCfg := $baseDockercfg | b64dec | fromJson }}
+{{- $auths := $baseCfg.auths | default dict }}
+{{- if $moduleDockercfg }}
+  {{- $moduleCfg := $moduleDockercfg | b64dec | fromJson }}
+  {{- $auths = merge $auths ($moduleCfg.auths | default dict) }}
+{{- end }}
+{{- $deckhouseDockercfg := set $baseCfg "auths" $auths | toJson | b64enc }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -21,4 +38,4 @@ metadata:
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ .Values.global.modulesImages.registry.dockercfg }}
+  .dockerconfigjson: {{ $deckhouseDockercfg }}


### PR DESCRIPTION
## Description

Adjusts the `deckhouse-registry` image pull secret generated in the module namespace so that its `auths` dictionary matches the registry actually used for image pulls:

- When the `storage-foundation` module is **enabled**, the secret contains only the module's own registry auth. The module and `storage-foundation` share a single registry source, so the module dockercfg already authenticates the storage-foundation CSI images.
- When `storage-foundation` is **disabled**, the secret merges the module's auth with the DKP (global) registry auth, which is required for the common CSI sidecar images.

Analogous to deckhouse/sds-local-volume#233.

## Why do we need it, and what problem does it solve?

When `storage-foundation` is enabled, the CSI sidecar images are pulled from the storage-foundation registry instead of the common DKP registry (see the shared `helm_lib_csi_image_with_common_fallback` helper). The previously generated secret always included the DKP auth regardless of which registry the images came from, so the `auths` set did not reflect the real pull source. This change makes the generated auth dictionary depend on whether `storage-foundation` is enabled.

## What is the expected result?

```
kubectl -n d8-<module> get secret deckhouse-registry -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d | jq '.auths | keys'
```

- With `storage-foundation` enabled: `auths` MUST contain only the module's registry host.
- With `storage-foundation` disabled: `auths` MUST contain both the module's registry host and the DKP (global) registry host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)