### PR TITLE
fix(crds): tolerate empty sibling block in CephStorageClass validation

### DIFF
--- a/crds/cephstorageclass.yaml
+++ b/crds/cephstorageclass.yaml
@@ -30,11 +30,17 @@ spec:
               type: object
               x-kubernetes-validations:
                 - rule: |
-                    (self.type == "CephFS" && has(self.cephFS) && !has(self.rbd)) || self.type != "CephFS"
-                  message: "Field 'cephFS' is required for 'CephFS' type, and 'rbd' field is forbidden"
+                    self.type != "CephFS" || (has(self.cephFS) && has(self.cephFS.fsName) && self.cephFS.fsName != "")
+                  message: "Field 'cephFS.fsName' is required for 'CephFS' type."
                 - rule: |
-                    (self.type == "RBD" && has(self.rbd) && !has(self.cephFS)) || self.type != "RBD"
-                  message: "Field 'rbd' is required for 'RBD' type, and 'cephFS' field is forbidden"
+                    self.type != "CephFS" || !has(self.rbd) || !has(self.rbd.pool) || self.rbd.pool == ""
+                  message: "Field 'rbd' is forbidden for 'CephFS' type."
+                - rule: |
+                    self.type != "RBD" || (has(self.rbd) && has(self.rbd.pool) && self.rbd.pool != "")
+                  message: "Field 'rbd.pool' is required for 'RBD' type."
+                - rule: |
+                    self.type != "RBD" || !has(self.cephFS) || !has(self.cephFS.fsName) || self.cephFS.fsName == ""
+                  message: "Field 'cephFS' is forbidden for 'RBD' type."
               required:
                 - clusterConnectionName
                 - reclaimPolicy
@@ -81,23 +87,18 @@ spec:
                   type: object
                   description: |
                     CephFS specific parameters.
-                  required:
-                    - fsName
                   properties:
                     fsName:
                       description: |
                         Name of the CephFS file system.
                       type: string
                       x-kubernetes-validations:
-                        - rule: self == oldSelf
+                        - rule: self == oldSelf || oldSelf == ""
                           message: Value is immutable.
-                      minLength: 1
                 rbd:
                   type: object
                   description: |
                     Rados Block Device specific parameters.
-                  required:
-                    - pool
                   properties:
                     defaultFSType:
                       description: |
@@ -105,17 +106,15 @@ spec:
                       type: string
                       default: ext4
                       x-kubernetes-validations:
-                        - rule: self == oldSelf
+                        - rule: self == oldSelf || oldSelf == ""
                           message: Value is immutable.
-                      minLength: 1
                     pool:
                       description: |
                         Name of the RBD pool.
                       type: string
                       x-kubernetes-validations:
-                        - rule: self == oldSelf
+                        - rule: self == oldSelf || oldSelf == ""
                           message: Value is immutable.
-                      minLength: 1
             status:
               type: object
               description: |


### PR DESCRIPTION
## Description

When creating a `CephStorageClass` with `type: RBD` through Deckhouse Console, the UI sends the `rbd` block together with a stale, empty `cephFS: { fsName: "" }` block. The CRD rejected this with **422 Unprocessable Content** because:

1. `spec.cephFS.fsName` had `minLength: 1`, so `""` failed; and
2. the spec-level rule `... && !has(self.cephFS)` forbade the `cephFS` field from being present at all for `type: RBD`.

Pushing the same resource via YAML without the extra block works fine.

This PR relaxes the CRD validation so an **empty** sibling block is tolerated, while a **meaningful** one is still rejected:

- The "sibling forbidden" rules now trigger only on non-empty content (`cephFS.fsName != ""` / `rbd.pool != ""`).
- The "active block must be populated" requirement moves from rigid `required`/`minLength` into type-gated CEL rules.
- Immutability of `fsName` / `pool` / `defaultFSType` is preserved.

The controller already branches on `spec.type` and ignores the inactive block ([ceph_storage_class_watcher_func.go](images/controller/pkg/controller/ceph_storage_class_watcher_func.go) L478-505), so this only removes a redundant hard failure.

> The root cause is in Deckhouse Console (the form seeds `cephFS:{fsName:""}` and does not strip it on type switch); a companion fix is being submitted there. This change makes the module robust regardless.

## Why do we need it, and what problem does it solve?

Creating an RBD `CephStorageClass` from the Console UI fails with 422. This restores that flow without weakening the validation contract.

## What is the expected result?

| Case | Before | After |
|------|--------|-------|
| `type: RBD` + `cephFS: { fsName: "" }` | ❌ 422 | ✅ accepted |
| `type: RBD` + `cephFS: { fsName: "real" }` | ❌ | ❌ rejected (meaningful sibling) |
| `type: RBD` without `rbd` / `rbd.pool: ""` | ❌ | ❌ rejected |
| `type: CephFS` + `cephFS: { fsName: "x" }` | ✅ | ✅ |
| `type: CephFS` without `cephFS` | ❌ | ❌ rejected |

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
