### PR TITLE
chore: set storage subsystem in module.yaml

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -1,5 +1,7 @@
 name: csi-ceph
 stage: "General Availability"
+subsystems:
+  - storage
 descriptions:
   en: "Provides integration with Ceph clusters, allows dynamic storage management and the use of StorageClass based on RBD (RADOS Block Device) or CephFS."
   ru: "Обеспечивает интеграцию с Ceph-кластерами, позволяет динамически управлять хранилищем и использовать StorageClass на основе RBD (RADOS Block Device) или CephFS."


### PR DESCRIPTION
## Description
Declare the `storage` subsystem in `module.yaml` by setting `subsystems: [storage]`.

## Why do we need it, and what problem does it solve?
Standardizes module metadata across all storage modules so each one consistently declares the `storage` subsystem. Modules that previously also listed `infrastructure` are normalized to `storage` only.

## What is the expected result?
`module.yaml` contains:
```yaml
subsystems:
  - storage
```
Metadata-only change; no runtime behavior is affected.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
