### PR TITLE
Sync base-images v1.2.0, Go 1.26.4, lib-helm 1.72.7

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,7 +1,6 @@
 module github.com/deckhouse/csi-ceph/api
 
-go 1.25.10
-
+go 1.26.4
 require k8s.io/apimachinery v0.34.1
 
 require (

--- a/hooks/go/go.mod
+++ b/hooks/go/go.mod
@@ -1,7 +1,6 @@
 module github.com/deckhouse/csi-ceph/hooks/go
 
-go 1.25.10
-
+go 1.26.4
 require (
 	github.com/deckhouse/csi-ceph/api v0.0.0-20251016081727-8de00d43187a
 	github.com/deckhouse/module-sdk v0.7.0

--- a/images/controller/go.mod
+++ b/images/controller/go.mod
@@ -1,7 +1,6 @@
 module github.com/deckhouse/csi-ceph/images/controller
 
-go 1.25.10
-
+go 1.26.4
 require (
 	github.com/deckhouse/csi-ceph/api v0.0.0-20250314071238-6a7df30c52cc
 	github.com/go-logr/logr v1.4.2

--- a/images/webhooks/go.mod
+++ b/images/webhooks/go.mod
@@ -1,7 +1,6 @@
 module github.com/deckhouse/csi-ceph/images/webhooks
 
-go 1.25.10
-
+go 1.26.4
 require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/slok/kubewebhook/v2 v2.7.0


### PR DESCRIPTION
## Description
Automated tooling sync for **csi-ceph** (scheduled `sync_storage_modules_tooling.py`).

- **BASE_IMAGES_VERSION**: left at `v1.2.0` (already matches latest release).
- **Go**: set `go 1.26.4` in **4** `go.mod` file(s) under `api/`, `images/` and `hooks/` (aligned with default `golang` image from `base_images.yml`).
- **lib-helm**: already **1.72.7**; chart bundle in `charts/` unchanged.

## Why do we need it, and what problem does it solve?
Keeps the module aligned with the latest **deckhouse/container-base/base-images** release and **deckhouse/lib-helm**
so CI and image builds use current base image digests, Go toolchain version, and Helm library charts.

## What is the expected result?
- Pipelines resolve `BASE_IMAGES_VERSION` to the new (or current) tag and download matching `base_images.yml`.
- Go code under `api/`, `images/` and `hooks/` declares the same Go version as the default `golang` toolchain in `base_images.yml`.
- `charts/` contains the current `deckhouse_lib_helm-*.tgz` when an update was required.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
