### PR TITLE
fix(werf): build base/vex from distroless via pm install

### DIFF
--- a/.werf/werf-base-for-vex.yaml
+++ b/.werf/werf-base-for-vex.yaml
@@ -1,25 +1,7 @@
 ---
 image: base/vex
-fromImage: tools/coreutils
+from: {{ index $.Images "builder/distroless" }}
 final: false
-import:
-- image: builder/alpine
-  add: /etc/ssl/certs/ca-certificates.crt
-  to: /etc/ssl/certs/ca-certificates.crt
-  before: install
-- image: tools/cosign
-  add: /usr/bin/cosign
-  to: /usr/bin/cosign
-  before: install
-- image: tools/jq
-  add: /usr/bin/jq
-  to: /usr/bin/jq
-  before: install
-- image: tools/curl
-  add: /usr/bin/curl-static
-  to: /usr/bin/curl
-  before: install
-- image: tools/bash
-  add: /usr/bin/bash
-  to: /bin/bash
-  before: install
+shell:
+  install:
+    - pm install coreutils ca-certificates cosign=2.6.3 jq curl bash


### PR DESCRIPTION
## Description

Rebuilds the `base/vex` image (`.werf/werf-base-for-vex.yaml`) the same way
`csi-nfs` and `sds-local-volume` do it — a single image `from` `builder/distroless`
with the tools installed via `pm install`, instead of `fromImage`/`import` of
per-tool base images:

```yaml
image: base/vex
from: {{ index $.Images "builder/distroless" }}
final: false
shell:
  install:
    - pm install coreutils ca-certificates cosign=2.6.3 jq curl bash
```

`.werf/defines/vex.tmpl` (the per-image `*-vex-artifact` + attestation logic) is
already byte-identical to those modules and is left unchanged.

No cluster components are affected — this only changes how build-time images are
assembled.

## Why do we need it, and what problem does it solve?

#173 (Add VEX attestation) shipped a `base/vex` that `fromImage`d / `import`ed werf
images that don't exist (`tools/coreutils`, `builder/alpine`, `tools/cosign`,
`tools/jq`, `tools/curl`, `tools/bash`). werf therefore could not even load the
build config:

```
unable to load werf config: image "builder/alpine" not found!   (image: base/vex)
```

`build_dev / Build and Push images` failed at config load — on `main`
(run 29178746379) and on every PR branched from it. This unblocks the build for
`main` and all downstream PRs.

(An interim revision materialised every base image as a werf image to satisfy the
imports; that loaded the config but exploded the build into hundreds of images and
was reverted in favour of the `pm install` approach above.)

## What is the expected result?

`build_dev / Build and Push images` succeeds again and the rendered image set stays
sane (module images + `base/vex`; no base-package images).

Verification:
- `werf config render` (v2.72.2) with a synthetic `base_images.yml`: fails to load
  before, renders cleanly after (18 images, no base-package explosion).
- CI: `build_dev / Build and Push images` is green on this branch; `base/vex/install`
  installs `cosign=2.6.3` and all image stages build. (The remaining red on the run
  is the pre-existing `CVE scan for PR` gate — an `UNKNOWN` finding for the
  unmaintained `golang.org/x/crypto/openpgp`, `GO-2026-5932`, in the `csi-ceph` /
  `go-hooks` gobinaries — unrelated to this change.)

## Checklist
- [ ] The code is covered by unit tests. <!-- N/A: werf build-config only, no application code -->
- [ ] e2e tests passed. <!-- N/A for a build-config fix -->
- [ ] Documentation updated according to the changes. <!-- N/A -->
- [x] Changes were tested (`werf config render` + CI `build_dev` build).
