### PR TITLE
fix(ci): use DEV registry password for DEV registry login in prod build

### DIFF
--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           registry: ${{ vars.DEV_REGISTRY }}
           registry_login: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.PROD_MODULES_REGISTRY_PASSWORD }}
+          registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
       - uses: deckhouse/modules-actions/build@v15
         with:
           module_source: "${{ vars.PROD_REGISTRY }}/${{ vars.PROD_MODULE_SOURCE_NAME }}/ce/modules"
@@ -96,7 +96,7 @@ jobs:
         with:
           registry: ${{ vars.DEV_REGISTRY }}
           registry_login: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.PROD_MODULES_REGISTRY_PASSWORD }}
+          registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
       - uses: deckhouse/modules-actions/build@v15
         with:
           module_source: "${{ vars.PROD_REGISTRY }}/${{ vars.PROD_MODULE_SOURCE_NAME }}/ee/modules"
@@ -141,7 +141,7 @@ jobs:
         with:
           registry: ${{ vars.DEV_REGISTRY }}
           registry_login: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.PROD_MODULES_REGISTRY_PASSWORD }}
+          registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
       - uses: deckhouse/modules-actions/build@v15
         with:
           module_source: "${{ vars.PROD_REGISTRY }}/${{ vars.PROD_MODULE_SOURCE_NAME }}/fe/modules"
@@ -186,7 +186,7 @@ jobs:
         with:
           registry: ${{ vars.DEV_REGISTRY }}
           registry_login: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.PROD_MODULES_REGISTRY_PASSWORD }}
+          registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
       - uses: deckhouse/modules-actions/build@v15
         with:
           module_source: "${{ vars.PROD_REGISTRY }}/${{ vars.PROD_MODULE_SOURCE_NAME }}/se/modules"
@@ -231,7 +231,7 @@ jobs:
         with:
           registry: ${{ vars.DEV_REGISTRY }}
           registry_login: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.PROD_MODULES_REGISTRY_PASSWORD }}
+          registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
       - uses: deckhouse/modules-actions/build@v15
         with:
           module_source: "${{ vars.PROD_REGISTRY }}/${{ vars.PROD_MODULE_SOURCE_NAME }}/se-plus/modules"


### PR DESCRIPTION
## Description

The prod build (`.github/workflows/build_prod.yml`) has two `modules-actions/setup@v4` login steps per job: the first logs into the **PROD** registry, the second into the **DEV** registry (`registry: ${{ vars.DEV_REGISTRY }}`, `registry_login: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}`).

The second (DEV) step was passing the **PROD** password:

```yaml
registry_password: ${{ secrets.PROD_MODULES_REGISTRY_PASSWORD }}   # wrong for the DEV registry
```

This changes it back to the DEV password in all editions (ce/ee/fe/se/se-plus):

```yaml
registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
```

The build step keeps the PROD credentials added in #173 — those are correct because `module_source` points to the PROD registry.

## Why do we need it, and what problem does it solve?

The mismatch was introduced in #173 (VEX attestation) and shipped in the v0.5.30 tag, breaking the release build. Every edition failed at the DEV registry login:

```
werf cr login -u csi-ceph -p *** dev-registry.deckhouse.io
Error: unable to authenticate into "dev-registry.deckhouse.io": Get "https://dev-registry.deckhouse.io/v2/": unauthorized: Auth failed.
```

Failing run: https://github.com/deckhouse/csi-ceph/actions/runs/29244151224

The DEV registry is used as the `secondary_repo` push target, so a valid DEV login is required for the prod build to succeed.

## What is the expected result?

A tagged prod build logs into both the PROD and DEV registries successfully and builds/pushes the module images for every edition.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
